### PR TITLE
Incorrect docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -410,7 +410,7 @@ Configuration
 
 The backend used to store follows
 
-Defaults to ``sequere.backends.database.Databasebackend``.
+Defaults to ``sequere.backends.database.DatabaseBackend``.
 
 ``SEQUERE_REDIS_CONNECTION``
 ............................


### PR DESCRIPTION
Fixed typo, there is no Databasebackend, it's DatabaseBackend

I also think the default is actually redis, not database. I got a redis connection error till I set this to DatabaseBackend. I'll leave that to you.
